### PR TITLE
[Web_App_Marketplace] fix(webapp): update updateAppFavourite to use boolean for active state

### DIFF
--- a/webapp/src/component/ui/AppCard.tsx
+++ b/webapp/src/component/ui/AppCard.tsx
@@ -68,7 +68,7 @@ export default function AppCard({
     const newFavoriteState = !isFavorite;
     setIsFavorite(newFavoriteState);
     dispatch(
-      updateAppFavourite({ id: appId, active: newFavoriteState ? 1 : 0 })
+      updateAppFavourite({ id: appId, active: newFavoriteState})
     );
   };
 

--- a/webapp/src/slices/appSlice/app.ts
+++ b/webapp/src/slices/appSlice/app.ts
@@ -53,7 +53,7 @@ const initialState: AppState = {
 
 interface UpdateArgs {
   id: number;
-  active: 1 | 0;
+  active: boolean;
 }
 
 export const fetchApps = createAsyncThunk(
@@ -95,27 +95,21 @@ export const updateAppFavourite = createAsyncThunk<
   UpdateArgs
 >(
   "apps/updateAppFavourite",
-  async ({ id, active }, { dispatch, rejectWithValue }) => {
+  async ( updateArgs, { dispatch, rejectWithValue }) => {
     APIService.getCancelToken().cancel();
     const newCancelTokenSource = APIService.updateCancelToken();
-
     try {
-      const normalized =
-        typeof active === "boolean" ? (active ? 1 : 0) : active;
-
       const res = await APIService.getInstance().patch(
-        AppConfig.serviceUrls.apps,
-        {},
+        `${AppConfig.serviceUrls.apps}/${updateArgs.id}`,
+        {
+          isFavourite: updateArgs.active
+        },
         {
           cancelToken: newCancelTokenSource.token,
-          params: {
-            id: id,
-            active: normalized,
-          },
+          
         }
       );
-
-      return { id: Number(id), active: normalized as 0 | 1 };
+      return { id: updateArgs.id, active: updateArgs.active};
     } catch (error: any) {
       if (axios.isCancel(error)) {
         return rejectWithValue("Request Canceled");
@@ -170,7 +164,7 @@ export const appSlice = createSlice({
         if (state.apps) {
           const app = state.apps.find((app) => app.id === action.payload.id);
           if (app) {
-            app.isFavourite = action.payload.active;
+            app.isFavourite = action.payload.active ? 1 : 0 ;
           }
         }
       });


### PR DESCRIPTION
This pull request updates the way app favorites are handled by switching from using numeric flags (1/0) to booleans for the favorite status throughout the codebase. The changes improve clarity and consistency in how favorite status is represented and communicated between the UI, Redux store, and API requests.

**Favorite status representation and handling:**

* Changed the `UpdateArgs` interface in `app.ts` to use a boolean for the `active` field instead of `1 | 0`, making the favorite status more intuitive and type-safe.
* Updated the `updateAppFavourite` thunk in `app.ts` to send the favorite status as a boolean (`isFavourite: updateArgs.active`) and simplified API request parameters. The API endpoint now uses a RESTful URL pattern and the request body uses a boolean.
* Modified the favorite toggle logic in `AppCard.tsx` to dispatch the new boolean-based favorite status instead of converting to numeric flags.

**Redux state update logic:**

* Updated the reducer logic in `app.ts` to convert the boolean favorite status back to a numeric value (`1` or `0`) for the `isFavourite` property in the app state, maintaining compatibility with existing state shape.