### PR TITLE
fix(UpdateAction): update enum values to use PascalCase for consistency

### DIFF
--- a/webapp/src/slices/appSlice/app.ts
+++ b/webapp/src/slices/appSlice/app.ts
@@ -102,7 +102,7 @@ export const upsertAppFavourite = createAsyncThunk<
     const newCancelTokenSource = APIService.updateCancelToken();
 
     try {
-      const action:UpdateAction = updateArgs.active ? UpdateAction.favorite : UpdateAction.unfavourite;
+      const action:UpdateAction = updateArgs.active ? UpdateAction.Favorite : UpdateAction.Unfavourite;
       
       const res = await APIService.getInstance().post(
         `${AppConfig.serviceUrls.apps}/${updateArgs.id}/${action}`,
@@ -166,7 +166,7 @@ export const appSlice = createSlice({
         if (state.apps) {
           const app = state.apps.find((app) => app.id === action.payload.id);
           if (app) {
-            app.isFavourite = action.payload.active === UpdateAction.favorite ? 1 : 0 ;
+            app.isFavourite = action.payload.active === UpdateAction.Favorite ? 1 : 0 ;
           }
         }
       });

--- a/webapp/src/types/types.tsx
+++ b/webapp/src/types/types.tsx
@@ -34,6 +34,6 @@ export interface CommonCardProps {
 }
 
 export enum UpdateAction {
-  favorite = "favourite",
-  unfavourite = "unfavourite"
+  Favorite = "favourite",
+  Unfavourite = "unfavourite"
 }


### PR DESCRIPTION
This pull request updates the `UpdateAction` enum to use capitalized member names and ensures consistent usage throughout the codebase. This aims to resolve the [comment](https://github.com/wso2-open-operations/web-app-marketplace/pull/8#discussion_r2425602334).

Enum updates and usage consistency:

* Capitalized the `UpdateAction` enum members from `favorite`/`unfavourite` to `Favorite`/`Unfavourite` in `webapp/src/types/types.tsx`.
* Updated references to the `UpdateAction` enum in the `upsertAppFavourite` thunk and the `appSlice` reducer to use the new capitalized member names. [[1]](diffhunk://#diff-5116a7801499a6b2938aa9b2d9f3de617b31493782df045c289ddc6ee46505fbL105-R105) [[2]](diffhunk://#diff-5116a7801499a6b2938aa9b2d9f3de617b31493782df045c289ddc6ee46505fbL169-R169)