### PR TITLE
feat: fix app name, enable help section and update team name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides context for Claude Code when working in this repository.
+
+## Project Overview
+
+**WSO2 App Store** is an open-source platform under the [wso2-open-operations](https://github.com/wso2-open-operations) organization for publishing, browsing, and managing internal web applications. It has a React frontend and a Ballerina backend service. Maintained by the **WSO2 Digital Team** (wso2-digital-team@wso2.com).
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Frontend | React 19, TypeScript 5.8, Vite 7 |
+| UI | Material-UI (MUI) 7, Emotion |
+| State | Redux Toolkit 2.8 |
+| Auth | Asgardeo (React SDK + SPA SDK) |
+| Forms | Formik + Yup |
+| HTTP | Axios + retry-axios |
+| Routing | React Router DOM 7 |
+| Backend | Ballerina 2201.10.4 |
+
+## Repository Structure
+
+```
+web-app-marketplace/
+├── backend/                  # Ballerina HTTP service (port 9090)
+│   ├── modules/
+│   │   ├── authorization/    # JWT/auth interceptors
+│   │   ├── database/         # DB operations
+│   │   └── people/           # User management
+│   ├── service.bal            # Main service entry point
+│   └── types.bal              # Shared type definitions
+└── webapp/                   # React frontend (port 3000)
+    └── src/
+        ├── app/               # App-level handlers
+        ├── component/         # Reusable components (common, layout, panel, ui)
+        ├── layout/            # Page layout components
+        ├── slices/            # Redux slices
+        ├── services/          # API service layer
+        ├── context/           # React contexts (AuthContext, DialogContext)
+        ├── config/            # App configuration
+        ├── utils/             # Utility functions
+        ├── types/             # TypeScript type definitions
+        ├── route.ts           # Route definitions
+        └── theme.ts           # MUI theme
+```
+
+## Development Commands
+
+All frontend commands run from the `webapp/` directory:
+
+```bash
+npm run dev          # Start dev server (localhost:3000)
+npm run build        # Production build
+npm run type-check   # TypeScript type checking
+npm run lint         # ESLint
+npm run format       # Prettier formatting
+npm run preview      # Preview production build
+```
+
+## Code Conventions
+
+### Naming
+- Components: PascalCase files in feature-based folders (`common/`, `panel/`, `ui/`)
+- Redux slices: camelCase with "Slice" suffix (e.g., `appSlice`, `authSlice`)
+- Constants: `UPPER_SNAKE_CASE` (e.g., `INTERNAL_APPS_THEME`)
+- Utilities/services: camelCase
+
+### Formatting (enforced by Prettier)
+- Double quotes, no single quotes
+- 2-space indentation
+- 100 character print width
+- Trailing commas always
+- Semicolons required
+- Imports sorted: third-party → React → project (`@src/`, `@component/`) → relative
+
+### TypeScript
+- Strict mode enabled
+- No unused locals or parameters
+- Path aliases: `@src/`, `@component/`, etc. (see `webapp/tsconfig.json`)
+
+### React Patterns
+- Context for auth state (`AuthContext`)
+- Redux for global app state
+- Asgardeo for SSO/OIDC authentication
+- Custom Axios interceptors for JWT and error handling
+
+## License
+
+Apache License 2.0 — WSO2 LLC (2025–2026). Add the Apache license header to new source files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides context for Claude Code when working in this repository.
 
 ## Project Overview
 
-**WSO2 App Store** is an open-source platform under the [wso2-open-operations](https://github.com/wso2-open-operations) organization for publishing, browsing, and managing internal web applications. It has a React frontend and a Ballerina backend service. Maintained by the **WSO2 Digital Team** (wso2-digital-team@wso2.com).
+**WSO2 Web App Marketplace** is an open-source platform under the [wso2-open-operations](https://github.com/wso2-open-operations) organization for publishing, browsing, and managing internal web applications. It has a React frontend and a Ballerina backend service. Maintained by the **WSO2 Digital Team** (wso2-digital-team@wso2.com).
 
 ## Tech Stack
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -27,7 +27,7 @@ under the License.
     <meta name="Web App Marketplace" content="Web App Marketplace WSO2 Employees" />
     <link rel="apple-touch-icon" href="/wso2-logo.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>WSO2 Apps Store</title>
+    <title>WSO2 App Store</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -27,7 +27,7 @@ under the License.
     <meta name="Web App Marketplace" content="Web App Marketplace WSO2 Employees" />
     <link rel="apple-touch-icon" href="/wso2-logo.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>WSO2 App Store</title>
+    <title>WSO2 Web App Marketplace</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/webapp/public/README.md
+++ b/webapp/public/README.md
@@ -1,0 +1,17 @@
+# WSO2 App Store - User Guide
+
+## Getting Started
+
+Browse and discover internal web applications available to WSO2 employees.
+
+## Features
+
+- **Browse Apps** – Explore all available internal web applications
+- **Favourites** – Mark apps as favourites for quick access
+- **Search & Filter** – Find apps by name or tags
+
+## Need Help?
+
+For any issues or queries, please reach out to the **WSO2 Digital Team**:
+
+📧 [wso2-digital-team@wso2.com](mailto:wso2-digital-team@wso2.com)

--- a/webapp/public/README.md
+++ b/webapp/public/README.md
@@ -1,4 +1,4 @@
-# WSO2 App Store - User Guide
+# WSO2 Web App Marketplace - User Guide
 
 ## Getting Started
 

--- a/webapp/src/route.ts
+++ b/webapp/src/route.ts
@@ -17,6 +17,7 @@ import AccountBoxOutlinedIcon from "@mui/icons-material/AccountBoxOutlined";
 import AdminPanelSettingsOutlinedIcon from "@mui/icons-material/AdminPanelSettingsOutlined";
 import AppsIcon from "@mui/icons-material/Apps";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import type { RouteObject } from "react-router-dom";
 
 import React from "react";
@@ -57,11 +58,6 @@ export const routes: RouteObjectWithRole[] = [
     allowRoles: [Role.ADMIN],
   },
 
-  /*
-   TODO: Implement User Guide page when the user guide content is ready.
-   The /help route is commented out for now and will be re-enabled once the
-   user guide page (View.help) is implemented.
-
   {
     path: "/help",
     text: "Help",
@@ -69,8 +65,7 @@ export const routes: RouteObjectWithRole[] = [
     element: React.createElement(View.help),
     allowRoles: [Role.ADMIN, Role.EMPLOYEE],
     bottomNav: true,
-  }
-  */
+  },
 ];
 
 export const getActiveRoutesV2 = (


### PR DESCRIPTION
- Fix title from "WSO2 Apps Store" to "WSO2 App Store"
- Enable /help route with HelpOutlineIcon for all users
- Add public/README.md with user guide and WSO2 Digital Team contact
- Update CLAUDE.md with correct app name and team reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Help section now accessible from app navigation.

* **Documentation**
  * Added comprehensive user guide covering Getting Started, browsing apps, favorites, search and filtering features.
  * Updated app branding in title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->